### PR TITLE
Temporary Punishments

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,7 @@
 {
     "prefix": "-",
     "botowner": "Phoenix#8577",
+    "GuildID": "713128888410046485",
     "roles": {
         "GUILD_MASTER": 713129672996683796,
         "TRUSTED": 713130133673738291,

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,14 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "deep-is": {
@@ -813,6 +821,13 @@
         "safe-buffer": "5.2.1",
         "sift": "7.0.1",
         "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "mongoose-legacy-pluralize": {
@@ -858,9 +873,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "discord.js": "^12.3.1",
     "hypixel-api": "^1.2.0",
-    "mongoose": "^5.10.9"
+    "mongoose": "^5.10.9",
+    "ms": "^2.1.3"
   },
   "devDependencies": {
     "eslint": "^7.10.0",

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -28,7 +28,6 @@ module.exports = {
             offender: member.id,
             moderator: message.author.id,
             reason: args[1],
-            active: true,
         }).save();
 
         await member.ban({ reason: args[1] });

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -24,7 +24,7 @@ module.exports = {
         const member = message.mentions.members.first();
 
         await new permban({
-            type: 'ban',
+            punishmenttype: 'ban',
             offender: member.id,
             moderator: message.author.id,
             reason: args[1],

--- a/src/commands/mute.js
+++ b/src/commands/mute.js
@@ -28,7 +28,6 @@ module.exports = {
             offender: member.id,
             moderator: message.author.id,
             reason: args[1],
-            active: true,
         }).save();
 
         let role = await message.guild.roles.cache.find(

--- a/src/commands/tempban.js
+++ b/src/commands/tempban.js
@@ -26,11 +26,12 @@ module.exports = {
             return await message.channel.send(
                 `:x: Error 425: Cannot ban for a negative amount of time!`
             );
-        if (!message.mentions.users.first())
+        if (!message.mentions.members.first())
             return await message.channel.send(
                 `:x: Error 404: User does not exist!`
             );
-        let banend = Date.now() - time;
+        // We don't check if the user is banned because he has to be mentioned to be banned
+        let banend = Date.now() + time;
         let member = await message.mentions.members.first();
         let user = await message.mentions.users.first();
         let guild = await message.guild;
@@ -47,6 +48,33 @@ module.exports = {
                 endTime: banend,
             },
         }).save();
+
+        const logembed = new MessageEmbed()
+            .setTitle(`${member} got tempbanned!`)
+            .setDescription(`${member} got tempbanned for ${args[1]}`)
+            .addFields(
+                {
+                    name: 'Offender: ',
+                    value: member.tag,
+                    inline: true,
+                },
+                {
+                    name: 'Moderator: ',
+                    value: message.author.tag,
+                    inline: true,
+                },
+                {
+                    name: 'Reason: ',
+                    value: args[2],
+                    inline: true,
+                },
+                {
+                    name: 'Duration: ',
+                    value: args[1],
+                }
+            );
+
+        await log(logembed);
 
         const oldtime = Date.now();
         setTimeout(async function () {
@@ -80,11 +108,11 @@ module.exports = {
                     },
                     {
                         name: 'Duration: ',
-                        value: ms(Date.now() - oldtime),
+                        value: ms(oldtime - Date.now()),
                     }
                 );
             await log(unbanembed);
-        });
+        }, time);
         await message.channel.send(
             `:white_check_mark: Succesfully banned ${user.tag} for ${args[1]}`
         );

--- a/src/commands/tempmute.js
+++ b/src/commands/tempmute.js
@@ -50,6 +50,33 @@ module.exports = {
             },
         }).save();
 
+        const logembed = new MessageEmbed()
+            .setTitle(`${member} got tempmuted!`)
+            .setDescription(`${member} got tempmuted for ${args[1]}`)
+            .addFields(
+                {
+                    name: 'Offender: ',
+                    value: member.tag,
+                    inline: true,
+                },
+                {
+                    name: 'Moderator: ',
+                    value: message.author.tag,
+                    inline: true,
+                },
+                {
+                    name: 'Reason: ',
+                    value: args[2],
+                    inline: true,
+                },
+                {
+                    name: 'Duration: ',
+                    value: args[1],
+                }
+            );
+
+        await log(logembed);
+
         const oldtime = Date.now();
         setTimeout(async function () {
             await tempmute.deleteOne({
@@ -58,9 +85,9 @@ module.exports = {
             });
             await member.roles.remove(role);
             const unbanembed = new MessageEmbed()
-                .setTitle(`${member}'s tempban expired!`)
+                .setTitle(`${member}'s tempmute expired!`)
                 .setDescription(
-                    `${member}'s tempban expired after ${ms(
+                    `${member}'s tempmute expired after ${ms(
                         Date.now() - oldtime
                     )}`
                 )

--- a/src/commands/tempmute.js
+++ b/src/commands/tempmute.js
@@ -1,0 +1,62 @@
+const config = require('../utils/config');
+const ms = require('ms');
+const tempmute = require('../models/tempmute');
+
+module.exports = {
+    name: 'tempmute',
+    description: 'Temporarily ',
+    usage: 'tempmute <member> <time> <reason>',
+    async execute(message, args) {
+        if (!message.member.hasPermission('BAN_MEMBERS'))
+            return await message.channel.send(
+                config.loadconfig().messages.unauthorized
+            );
+        if (!args[2])
+            return await message.channel.send(
+                config.loadconfig().messages.notenoughargs
+            );
+        if (Number(args[1]) || !ms(args[1]))
+            return await message.channel.send(
+                `:x: Error 405: Invalid time format!`
+            );
+        var time = ms(args[1]);
+        if (time < 0)
+            return await message.channel.send(
+                `:x: Error 425: Cannot mute for a negative amount of time!`
+            );
+        if (!message.mentions.members.first())
+            return await message.channel.send(
+                `:x: Error 404: User does not exist!`
+            );
+        let muteend = Date.now() + time;
+
+        let role = await message.guild.roles.cache.find(
+            (role) => role.id == config.loadconfig().roles.MUTED
+        );
+        let member = await message.mentions.members.first();
+
+        await member.roles.add(role);
+
+        await new tempmute({
+            punishmenttype: 'tempmute',
+            offender: member.id,
+            moderator: message.author.id,
+            reason: args[2],
+            duration: {
+                startTime: Date.now(),
+                endTime: muteend,
+            },
+        }).save();
+
+        setTimeout(async function () {
+            await tempmute.deleteOne({
+                punishmenttype: 'tempmute',
+                offender: member.id,
+            });
+            await member.roles.remove(role);
+        }, time);
+        await message.channel.send(
+            `:white_check_mark: Succesfully muted ${member.user.tag} for ${args[1]}`
+        );
+    },
+};

--- a/src/commands/unban.js
+++ b/src/commands/unban.js
@@ -1,0 +1,58 @@
+const { MessageEmbed } = require('discord.js');
+const log = require('../utils/log');
+const permban = require('../models/permban');
+const config = require('../utils/config');
+module.exports = {
+    name: 'unban',
+    description: 'Reverses a permanent ban',
+    usage: 'unban <userID> <reason>',
+    async execute(message, args) {
+        if (!message.member.hasPermission('BAN_MEMBERS'))
+            return await message.channel.send(
+                config.loadconfig().messages.unauthorized
+            );
+        if (!args[1])
+            return await message.channel.send(
+                config.loadconfig().messages.notenoughargs
+            );
+        if (!Number(args[0]))
+            return await message.channel.send(
+                `:x: Error 405: Not a valid User ID!`
+            );
+        if (
+            !(await permban.exists({
+                offender: args[0],
+                active: true,
+            }))
+        )
+            return await message.channel.send(
+                `:x: Error 405: User is not banned`
+            );
+        await permban.deleteOne({ offender: args[0] });
+        await message.guild.members.unban(args[0], args[1]);
+
+        const logembed = new MessageEmbed()
+            .setTitle(`${args[0]} got unbaned!`)
+            .setDescription(`${args[0]} got unbanned by ${message.author.tag}`)
+            .addFields(
+                {
+                    name: 'Offender:',
+                    value: `${args[0]}`,
+                    inline: true,
+                },
+                {
+                    name: 'Moderator:',
+                    value: `${message.author.tag} (${message.author.id})`,
+                    inline: true,
+                },
+                {
+                    name: 'Reason:',
+                    value: args[1] || 'No reason specified!',
+                    inline: true,
+                }
+            )
+            .setColor('#D0021B');
+
+        await log(logembed);
+    },
+};

--- a/src/commands/unmute.js
+++ b/src/commands/unmute.js
@@ -31,10 +31,9 @@ module.exports = {
                 ':x: Error 405: User is not muted!'
             );
         } else {
-            await permmute.updateOne(
-                { offender: message.mentions.members.first(), active: true },
-                { active: false }
-            );
+            await permmute.deleteOne({
+                offender: message.mentions.members.first().id,
+            });
             await message.member.roles.remove(
                 message.guild.roles.cache.find(
                     (role) => role.id == config.loadconfig().roles.MUTED

--- a/src/commands/unmute.js
+++ b/src/commands/unmute.js
@@ -2,6 +2,8 @@ const config = require('../utils/config');
 const permmute = require('../models/permmute');
 const log = require('../utils/log');
 const { MessageEmbed } = require('discord.js');
+const tempmute = require('../models/tempmute');
+const index = require('../index');
 
 module.exports = {
     name: 'unmute',
@@ -22,19 +24,38 @@ module.exports = {
                 ':x: Error 400: You need to mention a user!'
             );
         if (
-            !(await permmute.exists({
-                offender: message.mentions.members.first(),
-                active: true,
-            }))
+            !message.mentions.members
+                .first()
+                .roles.cache.some(
+                    (role) => role.id == config.loadconfig().roles.MUTED
+                )
         ) {
             return await message.channel.send(
                 ':x: Error 405: User is not muted!'
             );
         } else {
-            await permmute.deleteOne({
-                offender: message.mentions.members.first().id,
-            });
-            await message.member.roles.remove(
+            if (
+                await permmute.exists({
+                    offender: message.mentions.members.first().id,
+                    punishmenttype: 'mute',
+                })
+            ) {
+                await permmute.deleteOne({
+                    offender: message.mentions.members.first().id,
+                });
+            } else {
+                index.mutetimers.forEach((timer) => {
+                    if (
+                        timer.member.id == message.mentions.members.first().id
+                    ) {
+                        clearTimeout(timer.timeout);
+                    }
+                });
+                await tempmute.deleteOne({
+                    offender: message.mentions.members.first().id,
+                });
+            }
+            await message.mentions.members.first().roles.remove(
                 message.guild.roles.cache.find(
                     (role) => role.id == config.loadconfig().roles.MUTED
                 ),

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ client.on('ready', async () => {
             type: 'WATCHING',
         }
     );
-    const mutetimers = [];
+    const mutetimers = [{ member: '', timeout: '' }];
     var i = 0;
     for await (const doc of tempmute.find({ punishmenttype: 'tempmute' })) {
         const docject = doc.toObject();
@@ -39,7 +39,8 @@ client.on('ready', async () => {
         );
         const moderator = guild.members.cache.get(docject.moderator);
         if (docject.duration.endTime > Date.now()) {
-            mutetimers[i] = setTimeout(async function () {
+            mutetimers[i].member = member;
+            mutetimers[i].timeout = setTimeout(async function () {
                 await member.roles.remove(role);
                 const unmuteembed = new discord.MessageEmbed()
                     .setTitle(`${member}'s tempmute expired!`)
@@ -120,16 +121,17 @@ client.on('ready', async () => {
         }
     }
     i = 0;
-    const bantimers = [];
+    const bantimers = [{ user: '', timeout: '' }];
     for await (const doc of tempban.find({ punishmenttype: 'tempban' })) {
         const docject = doc.toObject();
         const guild = client.guilds.cache.get(
             await config.loadconfig().GuildID
         );
-        const user = client.users.cache.get(docject.offender);
+        const user = client.users.fetch(docject.offender);
         const moderator = client.users.cache.get(docject.moderator);
         if (docject.duration.endTime > Date.now()) {
-            bantimers[i] = setTimeout(async function () {
+            bantimers[i].user = user;
+            bantimers[i].timeout = setTimeout(async function () {
                 await tempban.deleteOne({
                     punishmenttype: 'tempban',
                     offender: user.id,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 const discord = require('discord.js');
 const fs = require('fs');
 const config = require('./utils/config.js');
+const tempmute = require('./models/tempmute.js');
+const log = require('./utils/log');
+const ms = require('ms');
 
 const client = new discord.Client();
 client.commands = new discord.Collection();
@@ -14,11 +17,116 @@ for (const file of commandFiles) {
     client.commands.set(command.name, command);
 }
 
-client.on('ready', () => {
-    console.log(`${client.user.tag}`);
-    client.user.setActivity('https://github.com/PhoenixGames-Phoenix/phx-bot', {
-        type: 'WATCHING',
-    });
+client.on('ready', async () => {
+    console.log(`Logged in as ${client.user.tag}`);
+    await client.user.setActivity(
+        'https://github.com/PhoenixGames-Phoenix/phx-bot',
+        {
+            type: 'WATCHING',
+        }
+    );
+    const timers = [];
+    var i = 0;
+    for await (const doc of tempmute.find({ punishmenttype: 'tempmute' })) {
+        const docject = doc.toObject();
+        const guild = client.guilds.cache.get(
+            await config.loadconfig().GuildID
+        );
+        const member = guild.members.cache.get(docject.offender);
+        const role = guild.roles.cache.find(
+            (role) => role.id == config.loadconfig().roles.MUTED
+        );
+        const moderator = guild.members.cache.get(docject.moderator);
+        if (docject.duration.endTime > Date.now()) {
+            timers[i] = setTimeout(
+                async function (member, role, docject, moderator) {
+                    await member.roles.remove(role);
+                    const unbanembed = new discord.MessageEmbed()
+                        .setTitle(`${member}'s tempmute expired!`)
+                        .setDescription(
+                            `${member}'s tempmute expired after ${ms(
+                                Date.now() - docject.duration.startTime
+                            )}`
+                        )
+                        .addFields(
+                            {
+                                name: 'Offender: ',
+                                value: member.tag,
+                                inline: true,
+                            },
+                            {
+                                name: 'Moderator: ',
+                                value: moderator.tag,
+                                inline: true,
+                            },
+                            {
+                                name: 'Reason: ',
+                                value: docject.reason,
+                                inline: true,
+                            },
+                            {
+                                name: 'Duration: ',
+                                value: ms(
+                                    docject.duration.endTime -
+                                        docject.duration.startTime
+                                ),
+                            }
+                        );
+                    await log(unbanembed);
+                    await tempmute.deleteOne({
+                        punishmenttype: 'tempmute',
+                        offender: member.id,
+                    });
+                }.bind(
+                    [member, role, docject, moderator],
+                    member,
+                    role,
+                    docject,
+                    moderator
+                ),
+                docject.duration.endTime - Date.now()
+            );
+            i++;
+        } else {
+            const unbanembed = new discord.MessageEmbed()
+                .setTitle(`${member}'s tempmute expired!`)
+                .setDescription(
+                    `${member}'s tempmute expired after ${ms(
+                        Date.now() - docject.duration.startTime
+                    )}`
+                )
+                .addFields(
+                    {
+                        name: 'Offender: ',
+                        value: member.tag,
+                        inline: true,
+                    },
+                    {
+                        name: 'Moderator: ',
+                        value: moderator.tag,
+                        inline: true,
+                    },
+                    {
+                        name: 'Reason: ',
+                        value: docject.reason,
+                        inline: true,
+                    },
+                    {
+                        name: 'Duration: ',
+                        value: ms(
+                            docject.duration.endTime -
+                                docject.duration.startTime
+                        ),
+                    }
+                );
+            await log(unbanembed);
+            await tempmute.deleteOne({
+                punishmenttype: 'tempmute',
+                offender: member.id,
+            });
+            await member.roles.remove(role);
+        }
+    }
 });
 
 client.on('message', (msg) => {
@@ -40,7 +148,7 @@ client.on('message', (msg) => {
         command.execute(msg, args);
     } catch (error) {
         console.error(error);
-        msg.reply(config.loadconfig().messages.commanderror);
+        msg.channel.send(config.loadconfig().messages.commanderror);
     }
 });
 

--- a/src/models/permban.js
+++ b/src/models/permban.js
@@ -1,12 +1,11 @@
 const conn = require('../utils/dbConnection');
-const { Schema } = require('mongoose');
+const mongoose = require('mongoose');
 
-const permbanSchema = new Schema({
-    type: { type: String },
-    offender: Number,
-    moderator: Number,
+const permbanSchema = new mongoose.Schema({
+    punishmenttype: String,
+    offender: String,
+    moderator: String,
     reason: String,
-    active: Boolean,
 });
 
 module.exports = conn.model('permban', permbanSchema, 'punishments');

--- a/src/models/permmute.js
+++ b/src/models/permmute.js
@@ -1,12 +1,11 @@
 const conn = require('../utils/dbConnection');
-const { Schema } = require('mongoose');
+const mongoose = require('mongoose');
 
-const permmuteSchema = new Schema({
-    type: { type: String },
-    offender: Number,
-    moderator: Number,
+const permmuteSchema = new mongoose.Schema({
+    punishmenttype: String,
+    offender: String,
+    moderator: String,
     reason: String,
-    active: Boolean,
 });
 
 module.exports = conn.model('mute', permmuteSchema, 'punishments');

--- a/src/models/tempban.js
+++ b/src/models/tempban.js
@@ -1,10 +1,10 @@
 const conn = require('../utils/dbConnection');
-const { Schema } = require('mongoose');
+const mongoose = require('mongoose');
 
-const tempbanSchema = new Schema({
-    type: { type: String },
-    offender: Number,
-    moderator: Number,
+const tempbanSchema = new mongoose.Schema({
+    punishmenttype: String,
+    offender: String,
+    moderator: String,
     reason: String,
     duration: {
         type: Object,

--- a/src/models/tempmute.js
+++ b/src/models/tempmute.js
@@ -1,10 +1,10 @@
 const conn = require('../utils/dbConnection');
-const { Schema } = require('mongoose');
+const mongoose = require('mongoose');
 
-const tempmuteSchema = new Schema({
-    type: { type: String },
-    offender: Number,
-    moderator: Number,
+const tempmuteSchema = new mongoose.Schema({
+    punishmenttype: String,
+    offender: String,
+    moderator: String,
     reason: String,
     duration: {
         type: Object,


### PR DESCRIPTION
# Temporary Punishments 

## Description
A new System implementing Temporary punishments, which are safe to use between restarts using the mongodb system implemented in #6 

## New Commands
2 New commands were added and 2 existing commands were modified
`tempmute <user> <time> <reason>`
`tempban <user> <time> <reason>`
These commands will temporarily ban or mute a member and will automatically unmute/unban the user when the bot is online at the time of expiry. The time is parsed using the [ms library](https://github.com/vercel/ms) so you have to format the time like "1h", "1m", "1d", etc.
The 2 changed commands are:
`unmute <userID> <reason>`
`unban <userID> <reason>`
with support for removing Temporary punishments using the UserID

## New Config
You'll now have to add the ID of the Guild the bot is running in. Multi-Guild Support is planned, but not here yet